### PR TITLE
Add option to store files in cpio

### DIFF
--- a/node_modules.py
+++ b/node_modules.py
@@ -27,7 +27,9 @@ import os
 import glob
 import subprocess
 import sys
+import stat
 import time
+import struct
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -41,6 +43,137 @@ MODULE_MAP = dict()
 
 # this is a hack for obs_scm integration
 OBS_SCM_COMPRESSION = None
+
+
+class CpioReader:
+    def __init__(self, fn):
+        self.fh = open(fn, 'rb')
+
+    def extract(self, outdir):
+
+        class CpioFile:
+            def __init__(self, fh):
+                self.fh = fh
+                self.name = None
+
+            def __enter__(self):
+                if (self.fh.tell() & 3):
+                    raise Exception("invalid offset %d" % fh.tell())
+
+                fmt = "6s8s8s8s8s8s8s8s8s8s8s8s8s8s"
+
+                fields = struct.unpack(fmt, self.fh.read(struct.calcsize(fmt)))
+
+                if fields[0] != b"070701":
+                    raise Exception("invalid cpio header %s" % fields[0])
+
+                names = ("c_ino", "c_mode", "c_uid", "c_gid",
+                         "c_nlink", "c_mtime", "c_filesize",
+                         "c_devmajor", "c_devminor", "c_rdevmajor",
+                         "c_rdevminor", "c_namesize", "c_check")
+                for (n, v) in zip(names, fields[1:]):
+                    setattr(self, n, int(v, 16))
+
+                self.name = struct.unpack('%ds' % (self.c_namesize - 1), self.fh.read(self.c_namesize - 1))[0]
+                self.fh.read(1)  # \0
+                if (self.c_namesize+2) % 4:
+                    self.fh.read(4 - (self.c_namesize+2) % 4)
+
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                if exc_type:
+                    return None
+                if self.c_filesize % 4:
+                    self.fh.read(4 - self.c_filesize % 4)
+
+            def last(self):
+                return self.name == b'TRAILER!!!'
+
+            def __str__(self):
+                return "[%s %d]" % (self.name, self.c_filesize)
+
+            def read(self):
+                return self.fh.read(self.c_filesize)
+
+
+        while True:
+            with CpioFile(self.fh) as f:
+                if f.last():
+                    break
+                with open(os.path.join(outdir if outdir else '.', os.path.basename(f.name.decode())), 'wb') as ofh:
+                    ofh.write(f.read())
+
+
+class CpioWriter:
+    def __init__(self, fn):
+        self.cpio = open(fn, 'wb')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type:
+            return None
+        self.add('TRAILER!!!', b'\0'*4)
+        return self
+
+    def add(self, name, content, perm=0o644):
+        if isinstance(name, str):
+            name = name.encode()
+        if isinstance(content, str):
+            content = content.encode()
+
+        name += b'\0'
+        mode = perm | 0x8000  # regular file
+
+        size = len(content)
+
+        header = b'070701%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%s' % (
+            0, mode, 0, 0, 1, 0, size, 0, 0, 0, 0, len(name), 0, name)
+
+        self.cpio.write(header)
+        if len(header):
+            self.cpio.write(b'\0' * (4 - len(header) % 4))
+        self.cpio.write(content)
+        if size % 4:
+            self.cpio.write(b'\0' * (4 - size % 4))
+
+    def addstream(self, name, fh):
+        if isinstance(name, str):
+            name = name.encode()
+        name += b'\0'
+
+        info = os.stat(fh.fileno())
+        size = info[stat.ST_SIZE]
+
+        header = b'070701%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%08x%s' % (
+            0,  # inode
+            info[stat.ST_MODE],
+            info[stat.ST_UID],
+            info[stat.ST_GID],
+            1,  # nlink
+            info[stat.ST_MTIME],
+            size,
+            0,  # major
+            0,  # minor
+            0,  # rmajor
+            0,  # rminor
+            len(name),
+            0,  # checksum
+            name
+            )
+
+        self.cpio.write(header)
+        if len(header) % 4:
+            self.cpio.write(b'\0' * (4 - len(header) % 4))
+        self.cpio.write(fh.read())
+        if size % 4:
+            self.cpio.write(b'\0' * (4 - size % 4))
+
+    def addfile(self, name):
+        with open(name, 'rb') as fh:
+            self.addstream(name, fh)
 
 
 def collect_deps_recursive(d, deps):
@@ -122,6 +255,8 @@ def collect_deps_recursive(d, deps):
             collect_deps_recursive(path, entry["dependencies"])
 
 
+
+
 def write_rpm_sources(fh, args):
     i = args.source_offset if args.source_offset is not None else ''
     for fn in sorted(MODULE_MAP):
@@ -198,6 +333,9 @@ def main(args):
                 fh.write("{} {}\n".format(fn, " ".join(sorted(MODULE_MAP[fn]["path"]))))
 
     if args.download:
+        if args.cpio and os.path.exists(args.cpio) and not args.download_always:
+            CpioReader(args.cpio).extract(args.outdir)
+
         for fn in sorted(MODULE_MAP):
             if args.file and fn not in args.file:
                 continue
@@ -283,6 +421,14 @@ def main(args):
                     )
                 )
 
+    if args.cpio:
+        with CpioWriter(_out(args.cpio) + ".new") as c:
+            for fn in sorted(MODULE_MAP):
+                with open(_out(fn), 'rb') as fh:
+                    c.addstream(os.path.basename(fn), fh)
+                os.unlink(_out(fn))
+        os.rename(_out(args.cpio) + ".new", _out(args.cpio))
+
     if args.obs_service:
         parser = ET.XMLParser(remove_blank_text=True)
         tree = ET.parse(args.obs_service, parser)
@@ -365,6 +511,9 @@ if __name__ == "__main__":
         "--outdir", metavar="DIR", help="where to put files"
     )
     parser.add_argument(
+        "--cpio", metavar="ARCHIVE", help="cpio archive to use instead of individual files"
+    )
+    parser.add_argument(
         "--compression", metavar="EXT", help="use EXT compression"
     )
     parser.add_argument(
@@ -390,6 +539,9 @@ if __name__ == "__main__":
         level = logging.WARNING
 
     logging.basicConfig(format='%(levelname)s:%(message)s', level=level)
+
+    if args.outdir and not args.outdir[0] == '/':
+        raise Exception("outdir must be absolute")
 
     if args.compression:
         OBS_SCM_COMPRESSION = args.compression

--- a/node_modules.py
+++ b/node_modules.py
@@ -266,7 +266,7 @@ def write_rpm_sources(fh, args):
 def main(args):
     # special settings when run as obs service
     if args.outdir:
-        if not args.spec:
+        if not args.spec and not args.output:
             specfiles = glob.glob('*.spec')
             if specfiles:
                 if len(specfiles) > 1:
@@ -475,7 +475,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="boilerplate python commmand line program"
+        description="Maintain spec file for node modules"
     )
     parser.add_argument("--dry", action="store_true", help="dry run")
     parser.add_argument("--debug", action="store_true", help="debug output")

--- a/node_modules.py
+++ b/node_modules.py
@@ -96,7 +96,6 @@ class CpioReader:
             def read(self):
                 return self.fh.read(self.c_filesize)
 
-
         while True:
             with CpioFile(self.fh) as f:
                 if f.last():
@@ -176,13 +175,14 @@ class CpioWriter:
             self.addstream(name, fh)
 
 
-def collect_deps_recursive(d, deps):
+def collect_deps_recursive(d, deps, skip_bundled=True):
     for module in sorted(deps):
         path = "/".join(("node_modules", module))
         if d:
             path = "/".join((d, path))
         entry = deps[module]
-        if "bundled" in entry and entry["bundled"]:
+        if skip_bundled and "bundled" in entry and entry["bundled"]:
+            logging.debug("skipping bundled %s", module)
             continue
         elif "resolved" not in entry:
             if "from" in entry:
@@ -252,9 +252,7 @@ def collect_deps_recursive(d, deps):
             MODULE_MAP[fn].setdefault("path", set()).add(path)
 
         if "dependencies" in entry:
-            collect_deps_recursive(path, entry["dependencies"])
-
-
+            collect_deps_recursive(path, entry["dependencies"], skip_bundled)
 
 
 def write_rpm_sources(fh, args):
@@ -266,8 +264,6 @@ def write_rpm_sources(fh, args):
 
 
 def main(args):
-    logging.info("main")
-
     # special settings when run as obs service
     if args.outdir:
         if not args.spec:
@@ -286,6 +282,7 @@ def main(args):
             args.checksums = 'node_modules.sums'
 
         args.download = True
+        args.include_bundled = True
 
     def _out(fn):
         return os.path.join(args.outdir, fn) if args.outdir else fn
@@ -299,7 +296,7 @@ def main(args):
         js = json.load(fh)
 
     if "dependencies" in js:
-        collect_deps_recursive("", js["dependencies"])
+        collect_deps_recursive("", js["dependencies"], args.include_bundled is False)
 
     if args.output:
         with open(_out(args.output), "w") as fh:
@@ -523,6 +520,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("--download", action="store_true", help="download files")
+    parser.add_argument("--include-bundled", action="store_true", help="don't skip bundled deps")
     parser.add_argument(
         "--download-always",
         action="store_true",

--- a/node_modules.py
+++ b/node_modules.py
@@ -338,6 +338,10 @@ def main(args):
                 continue
             url = MODULE_MAP[fn]["url"]
             if "scm" in MODULE_MAP[fn]:
+                if os.path.exists(_out(fn)) and MODULE_MAP[fn]["branch"] != "master" and not args.download_always:
+                    logging.info("skipping update of existing %s", _out(fn))
+                    continue
+
                 d = MODULE_MAP[fn]["basename"]
                 # TODO: use same cache as tar_scm
                 if os.path.exists(d):

--- a/node_modules.py
+++ b/node_modules.py
@@ -374,7 +374,7 @@ def main(args):
             else:
                 req = urllib.request.Request(url)
                 if os.path.exists(_out(fn)):
-                    if args.download_skip_existing:
+                    if not args.download_always:
                         logging.info("skipping download of existing %s", fn)
                         continue
                     stamp = time.strftime(
@@ -524,9 +524,9 @@ if __name__ == "__main__":
 
     parser.add_argument("--download", action="store_true", help="download files")
     parser.add_argument(
-        "--download-skip-existing",
+        "--download-always",
         action="store_true",
-        help="don't download existing files again",
+        help="download existing files again",
     )
 
     args = parser.parse_args()

--- a/node_modules.service
+++ b/node_modules.service
@@ -4,5 +4,12 @@
   <parameter name="cpio">
     <description>cpio file name to store all tarballs in</description>
   </parameter>
+  <parameter name="output">
+    <description>write rpm source lines to that file</description>
+  </parameter>
+  <parameter name="source-offset">
+    <description>rpm source number to start with</description>
+  </parameter>
+</service>
 </service>
 

--- a/node_modules.service
+++ b/node_modules.service
@@ -1,5 +1,8 @@
 <service name="node_modules">
   <summary>download node modules</summary>
   <description>download node modules</description>
+  <parameter name="cpio">
+    <description>cpio file name to store all tarballs in</description>
+  </parameter>
 </service>
 


### PR DESCRIPTION
Instead of having thousands of tarballs in the OBS source directory, add the option to store them in a cpio archive. That way it's quicker to upload and directory listings are shorter. The idea is to have a build time service extract the cpio so the resulting srpm actually has all invidvidual tarballs.