### PR TITLE
Fixes to make it work with the localhost npm proxy

### DIFF
--- a/node_modules.py
+++ b/node_modules.py
@@ -288,6 +288,9 @@ def main(args):
     with open(args.input) as fh:
         js = json.load(fh)
 
+    if not "lockfileVersion" in js or js["lockfileVersion"] != 2:
+        raise Exception("Only package-lock.json with lockfileVersion=2 are supported")
+
     if "dependencies" in js:
         collect_deps_recursive("", js["dependencies"])
 

--- a/node_modules.py
+++ b/node_modules.py
@@ -182,8 +182,16 @@ def collect_deps_recursive(d, deps):
             path = "/".join((d, path))
         entry = deps[module]
         if "resolved" not in entry:
+            # format of the "from" field is in `npm-package-arg` NPM package
             if "from" in entry:
-                o = urllib.parse.urlparse(entry["from"])
+                # can be prepended by name of the package
+                from_entry = entry["from"]
+                if from_entry[0] == '@':
+                    from_entry = from_entry[1:]
+                end_name_pos = from_entry.find('@')
+                from_entry = from_entry[end_name_pos+1:]
+
+                o = urllib.parse.urlparse(from_entry)
                 if o.scheme in ("git+http", "git+https"):
                     _, scheme = o.scheme.split("+")
                     branch = "master"

--- a/node_modules.py
+++ b/node_modules.py
@@ -272,9 +272,6 @@ def main(args):
             else:
                 raise Exception("This service needs a spec file to operate with")
 
-        if not args.locations:
-            args.locations = 'node_modules.loc'
-
         if not args.checksums:
             args.checksums = 'node_modules.sums'
 
@@ -319,11 +316,6 @@ def main(args):
             raise Exception("# NODE_MODULES [BEGIN|END] not found")
         if not args.outdir:
             os.rename(args.spec+".new", args.spec)
-
-    if args.locations:
-        with open(_out(args.locations), "w") as fh:
-            for fn in sorted(MODULE_MAP):
-                fh.write("{} {}\n".format(fn, " ".join(sorted(MODULE_MAP[fn]["path"]))))
 
     if args.download:
         if args.cpio and os.path.exists(args.cpio) and not args.download_always:
@@ -497,9 +489,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--checksums", metavar="FILE", help="Write BSD style checksum file"
-    )
-    parser.add_argument(
-        "--locations", metavar="FILE", help="Write locations into that file"
     )
     parser.add_argument(
         "--obs-service", metavar="FILE", help="OBS service file for download_url"

--- a/node_modules.py
+++ b/node_modules.py
@@ -175,16 +175,13 @@ class CpioWriter:
             self.addstream(name, fh)
 
 
-def collect_deps_recursive(d, deps, skip_bundled=True):
+def collect_deps_recursive(d, deps):
     for module in sorted(deps):
         path = "/".join(("node_modules", module))
         if d:
             path = "/".join((d, path))
         entry = deps[module]
-        if skip_bundled and "bundled" in entry and entry["bundled"]:
-            logging.debug("skipping bundled %s", module)
-            continue
-        elif "resolved" not in entry:
+        if "resolved" not in entry:
             if "from" in entry:
                 o = urllib.parse.urlparse(entry["from"])
                 if o.scheme in ("git+http", "git+https"):
@@ -252,7 +249,7 @@ def collect_deps_recursive(d, deps, skip_bundled=True):
             MODULE_MAP[fn].setdefault("path", set()).add(path)
 
         if "dependencies" in entry:
-            collect_deps_recursive(path, entry["dependencies"], skip_bundled)
+            collect_deps_recursive(path, entry["dependencies"])
 
 
 def write_rpm_sources(fh, args):
@@ -282,7 +279,6 @@ def main(args):
             args.checksums = 'node_modules.sums'
 
         args.download = True
-        args.include_bundled = True
 
     def _out(fn):
         return os.path.join(args.outdir, fn) if args.outdir else fn
@@ -296,7 +292,7 @@ def main(args):
         js = json.load(fh)
 
     if "dependencies" in js:
-        collect_deps_recursive("", js["dependencies"], args.include_bundled is False)
+        collect_deps_recursive("", js["dependencies"])
 
     if args.output:
         with open(_out(args.output), "w") as fh:
@@ -524,7 +520,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("--download", action="store_true", help="download files")
-    parser.add_argument("--include-bundled", action="store_true", help="don't skip bundled deps")
     parser.add_argument(
         "--download-always",
         action="store_true",


### PR DESCRIPTION
lockfileVersion=2 requirement is rather strict as otherwise the bundled dependency information is not resolved while `npm` still requires this information to install.

