### PR TITLE
Add support for package-lock.jsons

### DIFF
--- a/node_modules.py
+++ b/node_modules.py
@@ -267,6 +267,12 @@ def write_rpm_sources(fh, args):
         if args.source_offset is not None:
             i += 1
 
+def process_packagelock_file(js):
+    if not "lockfileVersion" in js or js["lockfileVersion"] != 2:
+        raise Exception("Only package-lock.json with lockfileVersion=2 are supported")
+
+    if "dependencies" in js:
+        collect_deps_recursive("", js["dependencies"])
 
 def main(args):
     # special settings when run as obs service
@@ -296,11 +302,12 @@ def main(args):
     with open(args.input) as fh:
         js = json.load(fh)
 
-    if not "lockfileVersion" in js or js["lockfileVersion"] != 2:
-        raise Exception("Only package-lock.json with lockfileVersion=2 are supported")
 
-    if "dependencies" in js:
-        collect_deps_recursive("", js["dependencies"])
+    if "name" in js:
+        process_packagelock_file(js)
+    else:
+        for i in js.keys():
+            process_packagelock_file(js[i])
 
     if args.output:
         with open(_out(args.output), "w") as fh:


### PR DESCRIPTION
Instead of handling single package-lock.json, add a feature to
handle multiple lock files in one file. For example,

```
{
  "1.4": `package-lock.json for 1.4 tag`,
  "1.5": `package-lock.json for 1.5 tag`,
  "2.0": `package-lock.json for 2.0 tag`
}
```