### PR TITLE
Add a path search for args.input

### DIFF
--- a/node_modules.py
+++ b/node_modules.py
@@ -37,6 +37,7 @@ from base64 import b64decode
 from binascii import hexlify
 from lxml import etree as ET
 
+from pathlib import Path
 
 # filename -> { url: <string>, sum: <string>, path = set([<string>, ..]) }
 MODULE_MAP = dict()
@@ -331,8 +332,10 @@ def main(args):
         with open(_out(fn), 'rb') as fh:
             h = hashlib.new(MODULE_MAP[fn].setdefault("algo", 'sha256'), fh.read())
             MODULE_MAP[fn]["chksum"] = h.hexdigest()
+    pattern = f"*{args.input}"
+    input_file = next(reversed(sorted(Path(Path.cwd()).glob(pattern))), None)
 
-    with open(args.input) as fh:
+    with open(input_file) as fh:
         js = json.load(fh)
 
 


### PR DESCRIPTION
If args.input file is generate by a service you need a path search to
find it.

Signed-off-by: Ronan Le Martret <ronan.lemartret@iot.bzh>