### PR TITLE
Support dependencies with multiple integrity values

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ externally download sources for use by `npm` during `rpmbuild`.
 ## As OBS service
 
 - Get `package-lock.json` with `localfileVersion: 2`. For example,
-  - `npm install --package-lock-only --legacy-peer-deps --ignore-scripts`
-    with npm 7+
+  - `npm install --package-lock-only --legacy-peer-deps` with npm 7+
   - `--legacy-peer-deps` is required to fetch peer dependencies from remote
     locally so they are available during peer resolution in the VM. Without
     this you may get additional warnings during install.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ externally download sources for use by `npm` during `rpmbuild`.
 ## As OBS service
 
 - Get `package-lock.json` with `localfileVersion: 2`. For example,
-  - `npm install --package-lock-only --legacy-peer-deps` with npm 7+
+  - `npm install --package-lock-only --legacy-peer-deps --ignore-scripts`
+    with npm 7+
   - `--legacy-peer-deps` is required to fetch peer dependencies from remote
     locally so they are available during peer resolution in the VM. Without
     this you may get additional warnings during install.

--- a/node_modules.py
+++ b/node_modules.py
@@ -225,8 +225,9 @@ def make_unique_fn_from_path(o):
 
     return '-'.join(prepended + [original_fn])
 
-def add_standard_dependency(o, integrity, module, install_path):
+def add_standard_dependency(o, integrities, module, install_path):
     url = urllib.parse.urlunparse(o)
+    integrity = integrities.split(" ")[0]
     algo, chksum = integrity.split("-", 2)
     chksum = hexlify(b64decode(chksum)).decode("ascii")
     fn = make_unique_fn_from_path(o)

--- a/node_modules.py
+++ b/node_modules.py
@@ -227,7 +227,8 @@ def make_unique_fn_from_path(o):
 
 def add_standard_dependency(o, integrities, module, install_path):
     url = urllib.parse.urlunparse(o)
-    integrity = integrities.split(" ")[0]
+    # pick the last integrity, assuming it will be better (e.g. sha1 vs sha256)
+    integrity = integrities.split(" ")[-1]
     algo, chksum = integrity.split("-", 2)
     chksum = hexlify(b64decode(chksum)).decode("ascii")
     fn = make_unique_fn_from_path(o)


### PR DESCRIPTION
Fixes #34 

This PR fixes the scenario where a `package-lock.json` file may include dependencies with multiple integrity values, as it would cause an error on the OBS side when building. The solution involves selecting the first defined integrity and checking against that, and ignoring any other one.