### PR TITLE
Pick the longest integrity value in package-lock.json

### DIFF
--- a/node_modules.py
+++ b/node_modules.py
@@ -227,8 +227,8 @@ def make_unique_fn_from_path(o):
 
 def add_standard_dependency(o, integrities, module, install_path):
     url = urllib.parse.urlunparse(o)
-    # pick the last integrity, assuming it will be better (e.g. sha1 vs sha256)
-    integrity = integrities.split(" ")[-1]
+    # pick the longest integrity assuming it will be better (eg sha1 vs sha256)
+    integrity = max(integrities.split(" "), key=len)
     algo, chksum = integrity.split("-", 2)
     chksum = hexlify(b64decode(chksum)).decode("ascii")
     fn = make_unique_fn_from_path(o)


### PR DESCRIPTION
In #35 it was suggested to pick the longest integrity instead of just the last element in the array. I had implemented it locally, but forgot to push again before the PR got merged. Sorry for that.

I'm including the change here since I think it could be useful.