### PR TITLE
Add --ignore-scripts to command to generate package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ externally download sources for use by `npm` during `rpmbuild`.
 ## As OBS service
 
 - Get `package-lock.json` with `localfileVersion: 2`. For example,
-  - `npm install --package-lock-only --legacy-peer-deps` with npm 7+
+  - `npm install --package-lock-only --legacy-peer-deps --ignore-scripts`
+    with npm 7+
   - `--legacy-peer-deps` is required to fetch peer dependencies from remote
     locally so they are available during peer resolution in the VM. Without
     this you may get additional warnings during install.


### PR DESCRIPTION
The NPM command to generate the `package-lock.json` could be improved by disabling execution of pre-install and post-install scripts, since we are only interested in obtaining the file.

In addition, it may fail under certain scenarios without the flag, so it might be a good idea to document it.