### PR TITLE
Add support for saving node_modules under a node_modules/ directory

### DIFF
--- a/node_modules.py
+++ b/node_modules.py
@@ -348,7 +348,7 @@ def collect_v3_deps(packages):
 def write_rpm_sources(fh, args):
     i = args.source_offset if args.source_offset is not None else ''
     for fn in sorted(MODULE_MAP):
-        fh.write("Source{}:         {}#/{}\n".format(i, MODULE_MAP[fn]["url"], fn))
+        fh.write("Source{}:         {}#/{}\n".format(i, MODULE_MAP[fn]["url"], ("node_modules/" if not args.cpio else "") + fn))
         if args.source_offset is not None:
             i += 1
 
@@ -420,14 +420,19 @@ def main(args):
     if args.download:
         if args.cpio and os.path.exists(args.cpio) and not args.download_always:
             CpioReader(args.cpio).extract(args.outdir)
+        if not args.cpio and not os.path.exists(_out("node_modules/")):
+            os.mkdir(_out("node_modules/"))
 
         for fn in sorted(MODULE_MAP):
             if args.file and fn not in args.file:
                 continue
+            fn_path = fn
+            if not args.cpio:
+                fn_path = "node_modules/" + fn
             url = MODULE_MAP[fn]["url"]
             if "scm" in MODULE_MAP[fn]:
-                if os.path.exists(_out(fn)) and MODULE_MAP[fn]["branch"] != "master" and not args.download_always:
-                    logging.info("skipping update of existing %s", _out(fn))
+                if os.path.exists(_out(fn_path)) and MODULE_MAP[fn]["branch"] != "master" and not args.download_always:
+                    logging.info("skipping update of existing %s", _out(fn_path))
                     continue
 
                 d = MODULE_MAP[fn]["basename"]
@@ -448,7 +453,7 @@ def main(args):
                         "archive",
                         "--format=tar." + (OBS_SCM_COMPRESSION if OBS_SCM_COMPRESSION else 'gz'),
                         "-o",
-                        _out(fn),
+                        _out(fn_path),
                         "--prefix",
                         "package/",
                         MODULE_MAP[fn]["branch"],
@@ -456,23 +461,23 @@ def main(args):
                     cwd=d,
                 )
                 if not args.outdir:
-                    os.rename(os.path.join(d, fn), fn)
+                    os.rename(os.path.join(d, fn_path), fn_path)
                 if r.returncode:
                     logging.error("failed to create tar %s", url)
                     continue
             else:
                 req = urllib.request.Request(url)
-                if os.path.exists(_out(fn)):
+                if os.path.exists(_out(fn_path)):
                     if not args.download_always:
                         logging.info("skipping download of existing %s", fn)
                         continue
                     stamp = time.strftime(
-                        "%a, %d %b %Y %H:%M:%S GMT", time.gmtime(os.path.getmtime(_out(fn)))
+                        "%a, %d %b %Y %H:%M:%S GMT", time.gmtime(os.path.getmtime(_out(fn_path)))
                     )
-                    logging.debug("adding If-Modified-Since %s: %s", fn, stamp)
+                    logging.debug("adding If-Modified-Since %s: %s", fn_path, stamp)
                     req.add_header("If-Modified-Since", stamp)
 
-                logging.info("fetching %s as %s", url, fn)
+                logging.info("fetching %s as %s", url, fn_path)
                 algo = MODULE_MAP[fn]["algo"]
                 chksum = MODULE_MAP[fn]["chksum"]
                 h = hashlib.new(algo)
@@ -483,21 +488,32 @@ def main(args):
                     if h.hexdigest() != chksum:
                         logging.error(
                             "checksum failure for %s %s %s %s",
-                            fn,
+                            fn_path,
                             algo,
                             h.hexdigest,
                             chksum,
                         )
                     else:
                         try:
-                            with open(_out(fn) + ".new", "wb") as fh:
+                            with open(_out(fn_path) + ".new", "wb") as fh:
                                 fh.write(data)
                         except OSError as e:
                             logging.error(e)
                         finally:
-                            os.rename(_out(fn) + ".new", _out(fn))
+                            os.rename(_out(fn_path) + ".new", _out(fn_path))
                 except urllib.error.HTTPError as e:
                     logging.error(e)
+
+    if not args.cpio:
+        for file in os.listdir(_out("node_modules/")):
+            found = False
+            for fn in sorted(MODULE_MAP):
+                if fn == file:
+                    found = True
+
+            if not found:
+                logging.info("Removing file: %s", _out("node_modules/" + file))
+                os.remove(_out("node_modules/" + file))
 
     if args.cpio:
         with CpioWriter(_out(args.cpio) + ".new") as c:


### PR DESCRIPTION
I've got this building under: https://src.opensuse.org/abrooks/cockpit-snapshots

It needs a few modifications to the spec that are done under: https://src.opensuse.org/abrooks/cockpit-snapshots/commit/efbb6b00037eb71bb0bcc31f91e41da837ce8132952ecc8066a7c9378992d51d

I've made this the default behavior when --cpio isn't provided