### PR TITLE
Add omit-optional service parameter and filter optional dependencies

### DIFF
--- a/node_modules.py
+++ b/node_modules.py
@@ -327,12 +327,14 @@ def fetch_non_resolved_dependency_location(entry, module, install_path):
     return False
 
 
-def collect_v2_deps_recursive(d, deps):
+def collect_v2_deps_recursive(d, deps, omit_optional=False):
     for module in sorted(deps):
+        entry = deps[module]
+        if omit_optional and entry.get("optional"):
+            continue
         path = "/".join(("node_modules", module))
         if d:
             path = "/".join((d, path))
-        entry = deps[module]
         if "resolved" not in entry:
             fetch_non_resolved_dependency_location(entry, module, path)
         else:
@@ -350,11 +352,13 @@ def collect_v2_deps_recursive(d, deps):
             )
 
         if "dependencies" in entry:
-            collect_v2_deps_recursive(path, entry["dependencies"])
+            collect_v2_deps_recursive(path, entry["dependencies"], omit_optional=omit_optional)
 
 
-def process_module(module, packages):
+def process_module(module, packages, omit_optional=False):
     entry = packages[module]
+    if omit_optional and entry.get("optional"):
+        return
     pos = module.find("node_modules/")
     if pos == -1:
         # All node modules are still installed under `*/node_modules/` in some workspace or not
@@ -383,7 +387,7 @@ def process_module(module, packages):
             )
 
 
-def collect_v3_deps(packages):
+def collect_v3_deps(packages, omit_optional=False):
     deps = packages.keys()
     # workspaces = packages[""]["workspaces"]
     # print(workspaces)
@@ -391,7 +395,7 @@ def collect_v3_deps(packages):
         if module == "":
             continue
 
-        process_module(module, packages)
+        process_module(module, packages, omit_optional=omit_optional)
 
 
 def write_rpm_sources(fh, args):
@@ -405,13 +409,13 @@ def write_rpm_sources(fh, args):
             i += 1
 
 
-def process_packagelock_file(js):
+def process_packagelock_file(js, omit_optional=False):
     if not "lockfileVersion" in js:
         raise Exception("Only package-lock.json with lockfileVersion=2+ are supported")
     elif js["lockfileVersion"] == 2:
-        collect_v2_deps_recursive("", js["dependencies"])
+        collect_v2_deps_recursive("", js["dependencies"], omit_optional=omit_optional)
     elif js["lockfileVersion"] == 3:
-        collect_v3_deps(js["packages"])
+        collect_v3_deps(js["packages"], omit_optional=omit_optional)
     else:
         raise Exception("Unsupported lockfileVersion found")
 
@@ -449,10 +453,10 @@ def main(args):
         js = json.load(fh)
 
     if "name" in js:
-        process_packagelock_file(js)
+        process_packagelock_file(js, omit_optional=args.omit_optional)
     else:
         for i in js.keys():
-            process_packagelock_file(js[i])
+            process_packagelock_file(js[i], omit_optional=args.omit_optional)
 
     if args.output and args.legacy_container:
         with open(_out(args.output), "w") as fh:
@@ -600,7 +604,7 @@ def main(args):
                             "checksum failure for %s %s %s %s",
                             fn,
                             algo,
-                            h.hexdigest,
+                            h.hexdigest(),
                             chksum,
                         )
                     else:
@@ -751,6 +755,14 @@ if __name__ == "__main__":
         const=True,
         default=False,
         help="look for cpio archive (legacy mode)",
+    )
+    parser.add_argument(
+        "--omit-optional",
+        type=str_to_bool,
+        nargs="?",
+        const=True,
+        default=False,
+        help="omit optional dependency download",
     )
     parser.add_argument(
         "--node-dir",

--- a/node_modules.service
+++ b/node_modules.service
@@ -13,6 +13,9 @@
   <parameter name="node-dir">
     <description>directory to store individual tarballs in when not using legacy-container</description>
   </parameter>
+  <parameter name="omit-optional">
+    <description>omit optional dependency download</description>
+  </parameter>
   <parameter name="output">
     <description>write rpm source lines to that file</description>
   </parameter>

--- a/test_parameters.py
+++ b/test_parameters.py
@@ -682,3 +682,145 @@ def test_include_file_sources_with_and_without_legacy_container(tmp_path):
     assert result_legacy.returncode == 0
     spec_content_legacy = (out_dir_legacy / "mock_legacy.spec").read_text()
     assert "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz#/ms-2.0.0.tgz" in spec_content_legacy
+
+
+def test_omit_optional_v2(tmp_path):
+    """Verify that --omit-optional filters out optional dependencies in a v2 package-lock."""
+    parent_dir = tmp_path.parent
+    lock_file = parent_dir / "package-lock.json"
+    lock_file.write_text("""{
+  "name": "v2-test",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "dependencies": {
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "optional": true
+    }
+  }
+}""")
+
+    spec_file = parent_dir / "mock.spec"
+    spec_file.write_text("# NODE_MODULES BEGIN\n# NODE_MODULES END\n")
+
+    # 1. Run WITH --omit-optional
+    out_dir_omit = tmp_path / "out_omit"
+    out_dir_omit.mkdir()
+    result = subprocess.run(
+        [
+            sys.executable,
+            NODE_MODULES_PY,
+            "-i", "package-lock.json",
+            "--spec", "mock.spec",
+            "--node-dir", "node_modules",
+            "--omit-optional",
+            "--outdir", str(out_dir_omit),
+            "--download",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=parent_dir,
+    )
+    assert result.returncode == 0
+    assert (out_dir_omit / "node_modules" / "ms-2.0.0.tgz").is_file()
+    assert not (out_dir_omit / "node_modules" / "negotiator-0.6.3.tgz").exists()
+
+    # 2. Run WITHOUT --omit-optional
+    out_dir_include = tmp_path / "out_include"
+    out_dir_include.mkdir()
+    result = subprocess.run(
+        [
+            sys.executable,
+            NODE_MODULES_PY,
+            "-i", "package-lock.json",
+            "--spec", "mock.spec",
+            "--node-dir", "node_modules",
+            "--outdir", str(out_dir_include),
+            "--download",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=parent_dir,
+    )
+    assert result.returncode == 0
+    assert (out_dir_include / "node_modules" / "ms-2.0.0.tgz").is_file()
+    assert (out_dir_include / "node_modules" / "negotiator-0.6.3.tgz").is_file()
+
+
+def test_omit_optional_v3(tmp_path):
+    """Verify that --omit-optional filters out optional dependencies in a v3 package-lock."""
+    parent_dir = tmp_path.parent
+    lock_file = parent_dir / "package-lock.json"
+    lock_file.write_text("""{
+  "name": "v3-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "optional": true
+    }
+  }
+}""")
+
+    spec_file = parent_dir / "mock.spec"
+    spec_file.write_text("# NODE_MODULES BEGIN\n# NODE_MODULES END\n")
+
+    # 1. Run WITH --omit-optional
+    out_dir_omit = tmp_path / "out_omit"
+    out_dir_omit.mkdir()
+    result = subprocess.run(
+        [
+            sys.executable,
+            NODE_MODULES_PY,
+            "-i", "package-lock.json",
+            "--spec", "mock.spec",
+            "--node-dir", "node_modules",
+            "--omit-optional",
+            "--outdir", str(out_dir_omit),
+            "--download",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=parent_dir,
+    )
+    assert result.returncode == 0
+    assert (out_dir_omit / "node_modules" / "ms-2.0.0.tgz").is_file()
+    assert not (out_dir_omit / "node_modules" / "negotiator-0.6.3.tgz").exists()
+
+    # 2. Run WITHOUT --omit-optional
+    out_dir_include = tmp_path / "out_include"
+    out_dir_include.mkdir()
+    result = subprocess.run(
+        [
+            sys.executable,
+            NODE_MODULES_PY,
+            "-i", "package-lock.json",
+            "--spec", "mock.spec",
+            "--node-dir", "node_modules",
+            "--outdir", str(out_dir_include),
+            "--download",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=parent_dir,
+    )
+    assert result.returncode == 0
+    assert (out_dir_include / "node_modules" / "ms-2.0.0.tgz").is_file()
+    assert (out_dir_include / "node_modules" / "negotiator-0.6.3.tgz").is_file()


### PR DESCRIPTION
To omit downloading dependencies marked as optional in package-lock.json, add a new 'omit-optional' parameter to the service definition and command line argument parser.

Pass the option to collect_v2_deps_recursive, collect_v3_deps, and process_module, and ignore packages where entry['optional'] is True when omit_optional is enabled. Also, fix an existing bug in checksum logging where the 'hexdigest' bound method was logged directly instead of being called.

Add unit tests to verify that both v2 and v3 package-locks omit optional dependency downloads when '--omit-optional' is specified.

Fixes: https://github.com/openSUSE/obs-service-node_modules/issues/49